### PR TITLE
Added ability to re-establish a session

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fishbowl-js",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A JavaScript wrapper for the Fishbowl API",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,22 @@ export = class Fishbowl {
   }
 
   /**
+   * Re-establish a previous session, should there be a connection failure, etc.
+   *
+   * @param info {SessionInfo}
+   */
+  public setSessionInfo(info: SessionInfo): void {
+    this.loggedIn = info.loggedIn;
+    this.username = info.username;
+    this.key = info.key;
+    this.host = info.host;
+    this.port = info.port;
+    this.IAID = info.IAID;
+    this.IAName = info.IAName;
+    this.IADescription = info.IADescription;
+  }
+
+  /**
    * @returns {SessionInfo}
    */
   public getSessionInfo(): SessionInfo {


### PR DESCRIPTION
This adds the ability to set the session info to re-establish a session that might still be active in FB from an error that has occurred, and prevents multiple Integration users from being logged in simultaneously.